### PR TITLE
Generate a Kotlin typealias to Any when type cannot be identified

### DIFF
--- a/src/main/kotlin/net/pwall/json/schema/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/net/pwall/json/schema/codegen/CodeGenerator.kt
@@ -91,6 +91,8 @@ class CodeGenerator(
     var templateName: String = "class",
     /** The primary template to use for the generation of an enum */
     var enumTemplateName: String = "enum",
+    /** The template to use for the generation of a default typealias */
+    var typealiasAnyTemplateName: String = "typealias_any",
     /** The base package name for the generated classes */
     var basePackageName: String? = null,
     /** The base output directory for generated files */
@@ -158,6 +160,12 @@ class CodeGenerator(
         val parser = templateParser
         val resolver = parser.resolvePartial
         parser.parse(parser.resolver(enumTemplateName))
+    }
+
+    var typealiasAnyTemplate by DefaultValue {
+        val parser = templateParser
+        val resolver = parser.resolvePartial
+        parser.parse(parser.resolver(typealiasAnyTemplateName))
     }
 
     var indexFileName: TargetFileName? = null
@@ -592,6 +600,12 @@ class CodeGenerator(
                 log.info { "-- target enum ${target.qualifiedClassName}" }
                 outputResolver(target.targetFile).use {
                     enumTemplate.appendTo(AppendableFilter(it), generatorContext.child(target))
+                }
+            }
+            constraints.isUnidentifiableType -> {
+                log.info { "-- generating typealias Any for ${target.className}" }
+                outputResolver(target.targetFile).use {
+                    typealiasAnyTemplate.appendTo(AppendableFilter(it), generatorContext.child(target))
                 }
             }
             else -> log.info { "-- nothing to generate for ${target.className}" }

--- a/src/main/kotlin/net/pwall/json/schema/codegen/Constraints.kt
+++ b/src/main/kotlin/net/pwall/json/schema/codegen/Constraints.kt
@@ -121,6 +121,10 @@ open class Constraints(val schema: JSONSchema, val negated: Boolean = false) : A
         get() = types.size == 1
 
     @Suppress("unused")
+    val isUnidentifiableType: Boolean
+        get() = types.size > 1
+
+    @Suppress("unused")
     val isObject: Boolean
         get() = isType(JSONSchema.Type.OBJECT) || types.isEmpty() && properties.isNotEmpty() // ?
 

--- a/src/main/resources/kotlin/typealias_any.mustache
+++ b/src/main/resources/kotlin/typealias_any.mustache
@@ -1,0 +1,6 @@
+{{>header}}{{#packageName}}package {{&packageName}}
+
+{{/packageName}}{{#constraints}}{{#schema}}{{#description}}/**
+ * {{&description}}
+ */
+{{/description}}{{/schema}}typealias {{&className}} = Any{{/constraints}}

--- a/src/test/kotlin/net/pwall/json/schema/codegen/CodeGeneratorCustomClassTest.kt
+++ b/src/test/kotlin/net/pwall/json/schema/codegen/CodeGeneratorCustomClassTest.kt
@@ -25,6 +25,7 @@
 
 package net.pwall.json.schema.codegen
 
+import net.pwall.json.JSON
 import kotlin.test.Test
 import kotlin.test.expect
 
@@ -297,6 +298,21 @@ class CodeGeneratorCustomClassTest {
         codeGenerator.addCustomClassByFormat("money", ClassName("Money", "com.example.util"))
         codeGenerator.generate(input)
         expect(createHeader("TestCustom.java") + expectedJavaForExtension) { stringWriter.toString() }
+    }
+
+    @Test fun `should generate a typealias for unknown type`() {
+        val input = File("src/test/resources/test-untyped.schema.json")
+        val schemaDoc = JSON.parse(input)
+        val codeGenerator = CodeGenerator()
+        val stringWriter1 = StringWriter()
+        val outputDetails1 = CodeGeneratorTestUtil.OutputDetails(TargetFileName("MyType", "kt", dirs), stringWriter1)
+        val stringWriter2 = StringWriter()
+        val outputDetails2 = CodeGeneratorTestUtil.OutputDetails(TargetFileName("Untyped", "kt", dirs), stringWriter2)
+        codeGenerator.basePackageName = "com.example"
+        codeGenerator.outputResolver = outputCapture(outputDetails1, outputDetails2)
+        codeGenerator.generateAll(schemaDoc, JSONPointer("/\$defs"))
+        expect(createHeader("MyType.kt") + expectedForMyType) { stringWriter1.toString() }
+        expect(createHeader("Untyped.kt") + expectedForUnknownType) { stringWriter2.toString() }
     }
 
     companion object {
@@ -591,6 +607,19 @@ public class TestCustom {
     }
 
 }
+"""
+
+        const val expectedForMyType =
+            """package com.example
+
+data class MyType(
+    val data: Untyped
+)
+"""
+        const val expectedForUnknownType =
+            """package com.example
+
+typealias Untyped = Any
 """
 
     }

--- a/src/test/resources/test-untyped.schema.json
+++ b/src/test/resources/test-untyped.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "MyType": {
+      "properties": {
+        "data": {
+          "$ref": "#/$defs/Untyped"
+        }
+      },
+      "required": [
+        "data"
+      ]
+    },
+    "Untyped": {
+      "type": [
+        "array",
+        "boolean",
+        "integer",
+        "number",
+        "object",
+        "string"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This supports a JSON schema type that allows all valid JSON. We are building an `Untyped` type that looks like the following:

```javascript
"Untyped": {
  "type": [
    "array",
    "boolean",
    "integer",
    "number",
    "object",
    "string"
  ]
}
```

Currently, Kotlin code is not generated for this type because a single type cannot be identified.

This PR adds an allowance for this and generates a `typealias = Any` to allow named references to this type.