### PR TITLE
Added depluralization of ies-ending plurals

### DIFF
--- a/src/main/kotlin/net/pwall/json/schema/codegen/CodeGenerator.kt
+++ b/src/main/kotlin/net/pwall/json/schema/codegen/CodeGenerator.kt
@@ -1835,6 +1835,7 @@ class CodeGenerator(
     }
 
     private fun String.depluralise(): String = when {
+        this.endsWith("ies") -> dropLast(3) + 'y'
 //        this.endsWith("es") -> dropLast(2) // need a more sophisticated way of handling plurals ending with -es
         this.endsWith('s') -> dropLast(1)
         else -> this


### PR DESCRIPTION
Plurals ending on `ies` should always map to singular forms ending on `y`. This one-liner should handle that.